### PR TITLE
Update SDK version to 2.1.9 and add vless_route_id field

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ pip install git+https://github.com/remnawave/python-sdk.git@development
 
 | Contract Version | Remnawave Panel Version |
 | ---------------- | ----------------------- |
-| 2.1.8            | >=2.1.8                 |
+| 2.1.9            | >=2.1.9                 |
+| 2.1.8            | ==2.1.8                 |
 | 2.1.7.post1      | ==2.1.7                 |
 | 2.1.4            | >=2.1.4, <2.1.7         |
 | 2.1.1            | >=2.1.1, <2.1.4         |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "remnawave"
-version = "2.1.8"
-description = "A Python SDK for interacting with the Remnawave API v2.1.8."
+version = "2.1.9"
+description = "A Python SDK for interacting with the Remnawave API v2.1.9."
 authors = [
     {name = "Artem",email = "dev@forestsnet.com"}
 ]

--- a/remnawave/models/hosts.py
+++ b/remnawave/models/hosts.py
@@ -61,6 +61,12 @@ class UpdateHostRequestDto(BaseModel):
         None,
         serialization_alias="overrideSniFromAddress",
     )
+    vless_route_id: Optional[int] = Field(
+        None,
+        serialization_alias="vlessRouteId",
+        ge=0,
+        le=65535
+    )
 
 
 class HostInboundData(BaseModel):
@@ -113,6 +119,10 @@ class HostResponseDto(BaseModel):
     override_sni_from_address: Optional[bool] = Field(
         None,
         serialization_alias="overrideSniFromAddress",
+    )
+    vless_route_id: Optional[int] = Field(
+        None,
+        serialization_alias="vlessRouteId",
     )
 
     # Legacy compatibility property
@@ -209,6 +219,12 @@ class CreateHostRequestDto(BaseModel):
     )
     server_description: Optional[str] = Field(
         None, alias="serverDescription", max_length=30
+    )
+    vless_route_id: Optional[int] = Field(
+        None,
+        serialization_alias="vlessRouteId",
+        ge=0,
+        le=65535
     )
 
     # Legacy compatibility property


### PR DESCRIPTION
Upgrade the SDK to version 2.1.9 and introduce the vless_route_id field in request and response models for enhanced functionality.