### PR TITLE
Add external_squad_uuid field and update SDK version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remnawave"
-version = "2.2.3"
+version = "2.2.3.post.b"
 description = "A Python SDK for interacting with the Remnawave API v2.2.3."
 authors = [
     {name = "Artem",email = "dev@forestsnet.com"}

--- a/remnawave/models/users.py
+++ b/remnawave/models/users.py
@@ -74,9 +74,6 @@ class CreateUserRequestDto(BaseModel):
 
 class UpdateUserRequestDto(BaseModel):
     uuid: UUID
-    active_internal_squads: list[str] | None = Field(
-        None, serialization_alias="activeInternalSquads"
-    )
     description: str | None = None
     email: str | None = None
     expire_at: datetime | None = Field(None, serialization_alias="expireAt")
@@ -92,6 +89,10 @@ class UpdateUserRequestDto(BaseModel):
     traffic_limit_strategy: TrafficLimitStrategy | None = Field(
         None, serialization_alias="trafficLimitStrategy"
     )
+    active_internal_squads: list[str] | None = Field(
+        None, serialization_alias="activeInternalSquads"
+    )
+    external_squad_uuid: UUID | None = Field(None, alias="externalSquadUuid")
 
 
 class UserResponseDto(BaseModel):


### PR DESCRIPTION
Introduce the `external_squad_uuid` field in the `UpdateUserRequestDto` class and reorganize the `active_internal_squads` field. Update the SDK version to 2.2.3.post.b.