### PR TITLE
fix: correct subscription format in happ crypto link generation

### DIFF
--- a/remnawave/utils/happ_crypt.py
+++ b/remnawave/utils/happ_crypt.py
@@ -52,6 +52,6 @@ def create_happ_crypto_link(content: str, method: Literal["v3", "v4"] = "v4") ->
             content.encode("utf-8"), padding.PKCS1v15()  # RSA_PKCS1_PADDING
         )
 
-        return "happ://crypt{" + method.lower().replace("v", "") + "/" + base64.b64encode(encrypted).decode()
+        return "happ://crypt" + method.lower().replace("v", "") + "/" + base64.b64encode(encrypted).decode()
     except Exception:
         return ""


### PR DESCRIPTION
## Problem
The `create_happ_crypto_link` function contained an extra opening bracket `{` which caused malformed subscription links. These links failed to import in the application.

## Solution
Removed the extra bracket to ensure proper subscription format.

## Impact
- Subscriptions can now be successfully imported into the application
- Fixed subscription link format validation