### PR TITLE
fix(api): remove isNodeOnline and isXrayRunning from NodeDto

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/copilot.data.migration.agent.xml
+++ b/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,32 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoredPackages">
+        <list>
+          <option value="aiogram" />
+          <option value="aioredis" />
+          <option value="redis" />
+          <option value="environs" />
+          <option value="loguru" />
+          <option value="SQLAlchemy" />
+          <option value="asyncpg" />
+          <option value="apscheduler" />
+          <option value="aiopayok" />
+          <option value="aioyookassa" />
+          <option value="pandas" />
+          <option value="xlsxwriter" />
+          <option value="aiohttp" />
+          <option value="aiofiles" />
+          <option value="ujson" />
+          <option value="PyYAML" />
+          <option value="phonenumbers" />
+          <option value="pydantic" />
+          <option value="cachetools" />
+          <option value="orjson" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="-503bf8:1987581b5b8:-7ffe" />
+      </MTProjectMetadataState>
+    </option>
+    <option name="titleBarState">
+      <MTProjectTitleBarConfigState>
+        <option name="overrideColor" value="false" />
+      </MTProjectTitleBarConfigState>
+    </option>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/python-sdk.iml" filepath="$PROJECT_DIR$/.idea/python-sdk.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/python-sdk.iml
+++ b/.idea/python-sdk.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/remnawave/models/webhook.py
+++ b/remnawave/models/webhook.py
@@ -219,8 +219,6 @@ class NodeDto(BaseModel):
     is_connected: bool
     is_connecting: bool
     is_disabled: bool
-    is_node_online: bool
-    is_xray_running: bool
     last_status_change: Optional[datetime] = None
     last_status_message: Optional[str] = None
 

--- a/remnawave/utils/happ_crypt.py
+++ b/remnawave/utils/happ_crypt.py
@@ -52,6 +52,6 @@ def create_happ_crypto_link(content: str, method: Literal["v3", "v4"] = "v4") ->
             content.encode("utf-8"), padding.PKCS1v15()  # RSA_PKCS1_PADDING
         )
 
-        return "happ://crypt{" + method.lower().replace("v", "") + "/" + base64.b64encode(encrypted).decode()
+        return "happ://crypt" + method.lower().replace("v", "") + "/" + base64.b64encode(encrypted).decode()
     except Exception:
         return ""


### PR DESCRIPTION
## What was changed

Removed the following fields from `NodeDto`:
- `is_node_online`
- `is_xray_running`

These fields were previously required in the DTO but are no longer present
in the API responses.

## Why

The API no longer provides `isNodeOnline` and `isXrayRunning`, but the DTO
still expected them as required fields.  
This caused Pydantic v2 validation errors when processing webhook payloads:

- `Field required: isNodeOnline`
- `Field required: isXrayRunning`
## Impact

- Webhook payload parsing no longer fails with validation errors
- `NodeDto` is now fully aligned with the current API contract
- No behavior changes, as these fields were not used in application logic

## Notes

If runtime node status is needed in the future, it should be introduced
as a separate internal model and not mixed into the API DTO.
