### PR TITLE
feat!: change traffic bytes type in UserTrafficDto model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
@@ -178,7 +178,7 @@ test.py
 docs/
 openapi/
 .DS_Store
-requirements.txt 
+requirements.txt
 requirements.in
 test_raw.py
 tests/test_one_time.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.11,<4.0"
+requires-python = ">=3.11,<3.13"
 dependencies = [
     "rapid-api-client (==0.6.0)",
     "orjson (>=3.10.15,<4.0.0)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "rapid-api-client (==0.6.0)",
     "orjson (>=3.10.15,<4.0.0)",

--- a/remnawave/models/users.py
+++ b/remnawave/models/users.py
@@ -109,8 +109,8 @@ class UpdateUserRequestDto(BaseModel):
 
 class UserTrafficDto(BaseModel):
     """User traffic information"""
-    used_traffic_bytes: float = Field(alias="usedTrafficBytes")
-    lifetime_used_traffic_bytes: float = Field(alias="lifetimeUsedTrafficBytes")
+    used_traffic_bytes: int = Field(alias="usedTrafficBytes")
+    lifetime_used_traffic_bytes: int = Field(alias="lifetimeUsedTrafficBytes")
     online_at: Optional[datetime] = Field(None, alias="onlineAt")
     first_connected_at: Optional[datetime] = Field(None, alias="firstConnectedAt")
     last_connected_node_uuid: Optional[UUID] = Field(None, alias="lastConnectedNodeUuid")
@@ -148,12 +148,12 @@ class UserResponseDto(BaseModel):
     user_traffic: UserTrafficDto = Field(alias="userTraffic")
     
     @property
-    def used_traffic_bytes(self) -> float:
+    def used_traffic_bytes(self) -> int:
         """Backward compatibility property"""
         return self.user_traffic.used_traffic_bytes
     
     @property
-    def lifetime_used_traffic_bytes(self) -> float:
+    def lifetime_used_traffic_bytes(self) -> int:
         """Backward compatibility property"""
         return self.user_traffic.lifetime_used_traffic_bytes
     


### PR DESCRIPTION
Fix Python 3.14 build & traffic types

Changes:

requires-python → >=3.11,<3.14 (PyO3 0.24.1 incompatibility)
uv.lock → .gitignore (library project)
UserTrafficDto: float → int for byte fields
Updated @property return types

Breaking:

Traffic fields now return int instead of float