### PR TITLE
fix: HWID/subscription-request-history — userUuid → userId (API v2.8.0)

### DIFF
--- a/remnawave/models/hwid.py
+++ b/remnawave/models/hwid.py
@@ -22,7 +22,8 @@ class DeleteUserHwidDeviceRequestDto(BaseModel):
 
 class HwidDeviceDto(BaseModel):
     hwid: str
-    user_uuid: UUID = Field(alias="userUuid")
+    user_id: int = Field(alias="userId")
+    request_ip: Optional[str] = Field(None, alias="requestIp")
     platform: Optional[str] = None
     os_version: Optional[str] = Field(None, alias="osVersion")
     device_model: Optional[str] = Field(None, alias="deviceModel")

--- a/remnawave/models/subscription_request_history.py
+++ b/remnawave/models/subscription_request_history.py
@@ -1,13 +1,12 @@
 from datetime import datetime
 from typing import List, Optional
-from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 
 class SubscriptionRequestHistoryRecord(BaseModel):
     id: int
-    user_uuid: UUID = Field(alias="userUuid")
+    user_id: int = Field(alias="userId")
     request_ip: Optional[str] = Field(alias="requestIp")
     user_agent: Optional[str] = Field(alias="userAgent")
     request_at: datetime = Field(alias="requestAt")

--- a/remnawave/models/users.py
+++ b/remnawave/models/users.py
@@ -222,7 +222,7 @@ class ResolveUserResponseDto(BaseModel):
 class SubscriptionRequestRecord(BaseModel):
     """Subscription request history record"""
     id: int
-    user_uuid: UUID = Field(alias="userUuid")
+    user_id: int = Field(alias="userId")
     request_at: datetime = Field(alias="requestAt")
     request_ip: Optional[str] = Field(alias="requestIp")
     user_agent: Optional[str] = Field(alias="userAgent")

--- a/remnawave/models/webhook.py
+++ b/remnawave/models/webhook.py
@@ -119,7 +119,8 @@ class UserEventDto(BaseModel):
 
 class HwidUserDeviceDto(BaseModel):
     hwid: str
-    user_uuid: UUID
+    user_id: Optional[int] = None
+    request_ip: Optional[str] = None
     platform: Optional[str] = None
     os_version: Optional[str] = None
     device_model: Optional[str] = None


### PR DESCRIPTION
## Проблема

Панель Remnawave **v2.8.0** в ответах HWID-устройств и истории запросов подписки
убрала `userUuid` и отдаёт `userId` (number), плюс добавила `requestIp` у HWID-устройств
(см. changelog v2.8.0 — *Replaced userUuid with userId in HWID devices and subscription request history*).

REST- и webhook-модели SDK под это не обновили. В результате парсинг вебхука
`user_hwid_devices.*` падает ещё в `WebhookUtility.parse_webhook`:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for HwidUserDeviceDto
userUuid
  Field required [type=missing, input_value={'hwid': '...','userId': ...}, input_type=dict]
```

## Изменения

- `models/webhook.py` — `HwidUserDeviceDto`: `user_uuid: UUID` → `user_id: Optional[int]`, добавлен `request_ip`.
  Сделано Optional намеренно: вебхук-payload не должен ронять `parse_webhook`, даже если поле отсутствует.
- `models/hwid.py` — `HwidDeviceDto` (response): `userUuid` → `userId`, добавлен `requestIp`.
- `models/subscription_request_history.py` и `models/users.py` — `SubscriptionRequest*Record`: `userUuid` → `userId`.

Request-DTO (`Create/Delete...RequestDto`) **не тронуты** — там `userUuid` остаётся параметром запроса,
изменение затрагивает только response-объекты.

## Проверка

Установка в чистый venv + парсинг:
- реальный прод-пейлоад (`hwid` + `userId`, без `userUuid`) — парсится;
- payload вообще без `userId` — не падает (Optional);
- `HwidDeviceDto` с `userId`+`requestIp` — ок;
- legacy-payload со старым `userUuid` — не роняет модель (поле игнорируется).
